### PR TITLE
Patch runtime.dart

### DIFF
--- a/lib/runtime/exception.dart
+++ b/lib/runtime/exception.dart
@@ -1,0 +1,6 @@
+class RuntimeException implements Exception {
+  String cause;
+  RuntimeException(this.cause);
+
+  String toString() => "RuntimeException: $cause";
+}

--- a/lib/runtime/runtime.dart
+++ b/lib/runtime/runtime.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import '../client/client.dart';
 import 'event.dart';
 import 'context.dart';
+import 'exception.dart';
 
 /// A function which ingests and Event and a [Context]
 /// and returns a [InvocationResult]. The result is ecoded
@@ -104,7 +105,7 @@ class Runtime<T> {
 
         final func = _handlers[context.handler];
         if(func == null) {
-          throw Exception('No handler with name "${context.handler}" registered in runtime!');
+          throw RuntimeException('No handler with name "${context.handler}" registered in runtime!');
         }
         final event =
             Event.fromHandler(func.type, await nextInvocation.response);

--- a/lib/runtime/runtime.dart
+++ b/lib/runtime/runtime.dart
@@ -103,6 +103,9 @@ class Runtime<T> {
         final context = Context.fromNextInvocation(nextInvocation);
 
         final func = _handlers[context.handler];
+        if(func == null) {
+          throw Exception('No handler with name "${context.handler}" registered in runtime!');
+        }
         final event =
             Event.fromHandler(func.type, await nextInvocation.response);
         final result = await func.handler(context, event);


### PR DESCRIPTION
Does a null check before executing handler. Throws a descriptive error if null.

Solves https://github.com/awslabs/aws-lambda-dart-runtime/issues/8.