### PR TITLE
Change type of version parameter in AwsCognitoEvent from number to string

### DIFF
--- a/data/cognito_event.json
+++ b/data/cognito_event.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": "1",
     "triggerSource": "CustomMessage_SignUp/CustomMessage_ResendCode/CustomMessage_ForgotPassword/CustomMessage_VerifyUserAttribute",
     "region": "eu-west-1",
     "userPoolId": "1234567",

--- a/lib/events/cognito_event.dart
+++ b/lib/events/cognito_event.dart
@@ -5,7 +5,7 @@ part 'cognito_event.g.dart';
 @JsonSerializable()
 class AwsCognitoEvent {
   @JsonKey()
-  final int version;
+  final String version;
 
   @JsonKey()
   final String triggerSource;

--- a/lib/events/cognito_event.g.dart
+++ b/lib/events/cognito_event.g.dart
@@ -8,7 +8,7 @@ part of 'cognito_event.dart';
 
 AwsCognitoEvent _$AwsCognitoEventFromJson(Map<String, dynamic> json) {
   return AwsCognitoEvent(
-    version: json['version'] as int,
+    version: json['version'] as String,
     triggerSource: json['triggerSource'] as String,
     region: json['region'] as String,
     userPoolId: json['userPoolId'] as String,

--- a/test/cognito_event_test.dart
+++ b/test/cognito_event_test.dart
@@ -14,7 +14,7 @@ void main() {
     test("json got parsed and creates an event", () async {
       final event = AwsCognitoEvent.fromJson(json);
 
-      expect(event.version, equals(1));
+      expect(event.version, equals("1"));
       expect(event.userPoolId, equals("1234567"));
       expect(event.userName, equals("foo"));
       expect(event.response.smsMessage, equals("foo"));


### PR DESCRIPTION
…ring

"type '_OneByteString' is not a subtype of type 'int' in type cast"

AwsCognitoEvent was failing to parse as the version parameter comes through as a string not a number

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
