### PR TITLE
(fix) check if `nextInvocation` is null in exception

### DIFF
--- a/lib/runtime/runtime.dart
+++ b/lib/runtime/runtime.dart
@@ -104,8 +104,9 @@ class Runtime<T> {
         final context = Context.fromNextInvocation(nextInvocation);
 
         final func = _handlers[context.handler];
-        if(func == null) {
-          throw RuntimeException('No handler with name "${context.handler}" registered in runtime!');
+        if (func == null) {
+          throw RuntimeException(
+              'No handler with name "${context.handler}" registered in runtime!');
         }
         final event =
             Event.fromHandler(func.type, await nextInvocation.response);
@@ -113,8 +114,10 @@ class Runtime<T> {
 
         await _client.postInvocationResponse(result);
       } on Exception catch (error, stacktrace) {
-        await _client.postInvocationError(
-            nextInvocation.requestId, InvocationError(error, stacktrace));
+        if (nextInvocation != null) {
+          await _client.postInvocationError(
+              nextInvocation.requestId, InvocationError(error, stacktrace));
+        }
       }
 
       nextInvocation = null;


### PR DESCRIPTION
This PR contains code to check whether if `nextInvocation` is null or not in the exception catcher of the `invoke` function. More details on the issue in #23.

closes #23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
